### PR TITLE
Fix Field.java documentation to refer to new IntField/FloatField/LongField/DoubleField #12125

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/document/Field.java
+++ b/lucene/core/src/java/org/apache/lucene/document/Field.java
@@ -36,10 +36,10 @@ import org.apache.lucene.util.BytesRef;
  * <ul>
  *   <li>{@link TextField}: {@link Reader} or {@link String} indexed for full-text search
  *   <li>{@link StringField}: {@link String} indexed verbatim as a single token
- *   <li>{@link IntPoint}: {@code int} indexed for exact/range queries.
- *   <li>{@link LongPoint}: {@code long} indexed for exact/range queries.
- *   <li>{@link FloatPoint}: {@code float} indexed for exact/range queries.
- *   <li>{@link DoublePoint}: {@code double} indexed for exact/range queries.
+ *   <li>{@link IntField}: {@code int} indexed for exact/range queries.
+ *   <li>{@link LongField}: {@code long} indexed for exact/range queries.
+ *   <li>{@link FloatField}: {@code float} indexed for exact/range queries.
+ *   <li>{@link DoubleField}: {@code double} indexed for exact/range queries.
  *   <li>{@link SortedDocValuesField}: {@code byte[]} indexed column-wise for sorting/faceting
  *   <li>{@link SortedSetDocValuesField}: {@code SortedSet<byte[]>} indexed column-wise for
  *       sorting/faceting


### PR DESCRIPTION
### Description
Replaced IntPoint, LongPoint, FloatPoint, and DoublePoint with IntField, LongField, FloatField, and DoubleField to make it  easier-to-use field subclasses.
<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
